### PR TITLE
Fixed padding for version text

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -152,7 +152,7 @@ h1, h2, h3 {
 h1 {
 	font-size: 2.875em;
 	margin-top: 0;
-	margin-bottom: 6%;
+	margin-bottom: 4%;
 	padding-bottom: 15px;
 	line-height: 1.4em;
 	text-shadow: 0px 2px 1px rgba(0, 0, 0, 0.2);
@@ -364,6 +364,9 @@ a, input, #dropdownmenu label, button {
 #row1 {
 	margin-bottom: 1.3%;
 	width: 100%;
+}
+#row1 h2 {
+	margin-bottom: 1.175em;
 }
 #row1 a, #row2 a {
 	color: #101010;


### PR DESCRIPTION
I forgot to include CSS code for the "Download for Minecraft 1.7 & 1.8"-text's padding.
