### PR TITLE
Temporarely removed repo link

### DIFF
--- a/plugins.html
+++ b/plugins.html
@@ -5,4 +5,4 @@ title: Plugins
 permalink: /plugins/
 ---
 <p>Plugins are an easy way to expand your server's functionality. There are many different first and third-party plugins available. Adding a plugin to your server is simple; you download a plugin, extract it to the <b>Plugins</b> folder inside your <b>Server</b> folder, and activate the plugin in the WebAdmin panel of your server.</p> 
-<p>You can find plugins for Cuberite in the <a href="https://cuberiteplugins.azurewebsites.net/">plugin repository</a> or the <a href="http://forum.mc-server.org/forumdisplay.php?fid=2">forum</a>.</p>
+<p>You can find plugins for Cuberite in the <a href="http://forum.mc-server.org/forumdisplay.php?fid=2">forum plugins section</a>.</p>


### PR DESCRIPTION
The less dead links we have, the more professional we look. The Plugin Repo is empty right now, no point in showcasing it at the homepage. It may give people an impression that we have no plugins.

We'll put back the link when it's actually ready.
