### PR TITLE
Removed bountysource Donate link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -106,7 +106,6 @@
 			<a href="https://forum.cuberite.org/" class="show-mobile">Forum</a>
 			<a href="/contribute/" class="show-mobile">Contribute</a>
 			<a href="/news/">News</a>
-			<a href="https://salt.bountysource.com/teams/cuberite">Donate</a>
 			<a href="https://api.cuberite.org/">API</a>
 			<a href="/privacy/">Privacy</a>
 			<div id="media-links">


### PR DESCRIPTION
From what I can tell, we don't use Bounty Source (much) anymore,
So I propose we remove it.