### PR TITLE
Specify Raspberry Pi 3/4

### DIFF
--- a/download-links.html
+++ b/download-links.html
@@ -20,7 +20,7 @@ description: 'This page contains the canonical download links for Cuberite, whic
 <ul>
 <li>32 bit x86: <a href="https://download.cuberite.org/linux-i386/Cuberite.tar.gz">https://download.cuberite.org/linux-i386/Cuberite.tar.gz</a></li>
 <li>64 bit x86: <a href="https://download.cuberite.org/linux-x86_64/Cuberite.tar.gz">https://download.cuberite.org/linux-x86_64/Cuberite.tar.gz</a></li>
-<li>armhf (Raspberry Pi 3/4): <a href="https://download.cuberite.org/linux-armhf-raspbian/Cuberite.tar.gz">https://download.cuberite.org/linux-armhf-raspbian/Cuberite.tar.gz</a></li>
+<li>armhf (Raspberry Pi 3-4): <a href="https://download.cuberite.org/linux-armhf-raspbian/Cuberite.tar.gz">https://download.cuberite.org/linux-armhf-raspbian/Cuberite.tar.gz</a></li>
 </ul>
 
 <h2>Windows Downloads</h2>

--- a/download-links.html
+++ b/download-links.html
@@ -20,7 +20,7 @@ description: 'This page contains the canonical download links for Cuberite, whic
 <ul>
 <li>32 bit x86: <a href="https://download.cuberite.org/linux-i386/Cuberite.tar.gz">https://download.cuberite.org/linux-i386/Cuberite.tar.gz</a></li>
 <li>64 bit x86: <a href="https://download.cuberite.org/linux-x86_64/Cuberite.tar.gz">https://download.cuberite.org/linux-x86_64/Cuberite.tar.gz</a></li>
-<li>armhf (Raspberry Pi): <a href="https://download.cuberite.org/linux-armhf-raspbian/Cuberite.tar.gz">https://download.cuberite.org/linux-armhf-raspbian/Cuberite.tar.gz</a></li>
+<li>armhf (Raspberry Pi 3/4): <a href="https://download.cuberite.org/linux-armhf-raspbian/Cuberite.tar.gz">https://download.cuberite.org/linux-armhf-raspbian/Cuberite.tar.gz</a></li>
 </ul>
 
 <h2>Windows Downloads</h2>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@ layout: default
 						<span class="downloadmenu">
 							<a href="https://download.cuberite.org/linux-i386/Cuberite.tar.gz">32-bit</a>
 							<a href="https://download.cuberite.org/linux-x86_64/Cuberite.tar.gz">64-bit</a>
-							<a href="https://download.cuberite.org/linux-armhf-raspbian/Cuberite.tar.gz">Raspberry Pi</a>
+							<a href="https://download.cuberite.org/linux-armhf-raspbian/Cuberite.tar.gz">Raspberry Pi 3/4</a>
 						</span>
 					</label>
 					<label class="downloadbutton" tabindex="0">

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@ layout: default
 						<span class="downloadmenu">
 							<a href="https://download.cuberite.org/linux-i386/Cuberite.tar.gz">32-bit</a>
 							<a href="https://download.cuberite.org/linux-x86_64/Cuberite.tar.gz">64-bit</a>
-							<a href="https://download.cuberite.org/linux-armhf-raspbian/Cuberite.tar.gz">Raspberry Pi 3/4</a>
+							<a href="https://download.cuberite.org/linux-armhf-raspbian/Cuberite.tar.gz">Raspberry Pi 3-4</a>
 						</span>
 					</label>
 					<label class="downloadbutton" tabindex="0">


### PR DESCRIPTION
Specify that the pre-compiled builds are for Raspberry Pi models 3 and 4, to avoid issues like: https://github.com/cuberite/cuberite/issues/5280.