### PR TITLE
Fix animations for menu expansion

### DIFF
--- a/_includes/_css/style.css
+++ b/_includes/_css/style.css
@@ -317,10 +317,10 @@ label.downloadbutton:focus-within {
 }
 .downloadbutton:hover > .downloadmenu,
 .downloadbutton:focus > .downloadmenu {
-	max-height: none;
+	max-height: 11.000em;
 }
 .downloadbutton:focus-within > .downloadmenu {
-	max-height: none;
+	max-height: 11.000em;
 }
 .downloadbutton > svg {
 	float: left;
@@ -576,7 +576,7 @@ button {
 		max-height: 0;
 	}
 	.downloadbutton > input:checked + .downloadmenu {
-		max-height: none;
+		max-height: 11.000em;
 	}
 	#show-desktop-downloads-button {
 		cursor: pointer;

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@ layout: default
 			<h1>A lightweight, fast and extensible game server for Minecraft</h1>
 			<h2>Download for Minecraft Java Edition 1.8 - 1.12.2</h2>
 			<div id="downloads">
+				<!-- Note: don't forget to update the CSS max-height of .downloadmenu when adding new items. -->
 				<div id="desktop-downloads">
 					<label class="downloadbutton" tabindex="0">
 						<svg aria-hidden="true" height="1.688em" viewBox="0 0 24 24" width="1.688em">


### PR DESCRIPTION
Ref #102. Seems `none` doesn't get animated, so we're forced to use a fixed value. Each menu item is 2.625em in height so rounded 11em total.