### PR TITLE
Change plugins button link

### DIFF
--- a/plugins.html
+++ b/plugins.html
@@ -9,7 +9,7 @@ description: 'Plugins let you add new gameplay features to your Cuberite server 
 	<div>
 		<h2>Install Plugins</h2>
 		<p>There are multiple plugins available to use, and installing them is easy. You can find most plugins available for Cuberite in our plugin repository.</p>
-		<a href="https://forum.cuberite.org/forum-2.html" class="button">Get Plugins</a>
+		<a href="https://plugins.cuberite.org/" class="button">Get Plugins</a>
 	</div>
 
 	<div>


### PR DESCRIPTION
I think the plugins button should redirect to https://plugins.cuberite.org/ instead of the forum because it's easier to find plugins there.